### PR TITLE
Enabling app install when only setup.py is present on Py3 and PyPy

### DIFF
--- a/pypy/deploy
+++ b/pypy/deploy
@@ -10,4 +10,6 @@ source ${SOURCE_DIR}/base/rc/config
 
 if [ -f ${CURRENT_DIR}/requirements.txt ]; then
     sudo pip install -r ${CURRENT_DIR}/requirements.txt
+elif [ -f ${CURRENT_DIR}/setup.py ]; then
+    sudo pip install -e ${CURRENT_DIR}/
 fi

--- a/python3/deploy
+++ b/python3/deploy
@@ -10,4 +10,6 @@ source ${SOURCE_DIR}/base/rc/config
 
 if [ -f ${CURRENT_DIR}/requirements.txt ]; then
     sudo pip3 install -r ${CURRENT_DIR}/requirements.txt
+elif [ -f ${CURRENT_DIR}/setup.py ]; then
+    sudo pip install -e ${CURRENT_DIR}/
 fi


### PR DESCRIPTION
This allows Python3 and Pypy packages to be installed when they don't have a requirements.txt file.