### PR TITLE
static: add script for validating nginx.conf

### DIFF
--- a/static/deploy
+++ b/static/deploy
@@ -12,3 +12,5 @@ source ${SOURCE_DIR}/base/deploy
 set +e
 test -e ${CURRENT_DIR}/nginx.conf && sudo cp ${CURRENT_DIR}/nginx.conf /etc/nginx/nginx.conf
 set -e
+
+${SOURCE_DIR}/static/validate-nginx-conf /etc/nginx/nginx.conf

--- a/static/validate-nginx-conf
+++ b/static/validate-nginx-conf
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+nginx_config_file=$1
+
+echo "Validating nginx configuration..."
+
+nginx -c ${nginx_config_file} -t
+
+grep -q "port_in_redirect\s\+off;" ${nginx_config_file} || echo "'port_in_redirect off' is mandatory on nginx.conf"


### PR DESCRIPTION
We can later on leverage this script in the CI or on build time on Docker Hub (running validate-nginx-conf as one of the steps of Dockerfile would break the build if we break nginx.conf, but having that
on a CI would be good as well).

Sending as a pull request because I didn't discuss with you guys before doing that :-)