### PR TITLE
static/deploy: move the configuration file instead of copying it

### DIFF
--- a/static/deploy
+++ b/static/deploy
@@ -10,5 +10,5 @@ source ${SOURCE_DIR}/base/rc/config
 source ${SOURCE_DIR}/base/deploy
 
 set +e
-test -e ${CURRENT_DIR}/nginx.conf && sudo cp ${CURRENT_DIR}/nginx.conf /etc/nginx/nginx.conf
+test -e ${CURRENT_DIR}/nginx.conf && sudo mv ${CURRENT_DIR}/nginx.conf /etc/nginx/nginx.conf
 set -e


### PR DESCRIPTION
Just to prevent serving the nginx.conf file.