### PR TITLE
Fixing how dependencies should work and installation of luarocks

### DIFF
--- a/lua/README.md
+++ b/lua/README.md
@@ -5,4 +5,4 @@ The Lua platform uses Lua 5.1 and latest LuaRocks available.
 ## Code deployment with dependencies
 
 We're using Luarocks to manage packages for Lua, and tsuru will expect
-for a file called `tsuru.rockspec` for dependencies definitions.
+for a file called `tsuru-1.0-1.rockspec` for dependencies definitions.

--- a/lua/deploy
+++ b/lua/deploy
@@ -8,8 +8,8 @@ SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/deploy
 source ${SOURCE_DIR}/base/rc/config
 
-if [ -f ${CURRENT_DIR}/tsuru.rockspec ]; then
+if [ -f ${CURRENT_DIR}/tsuru-1.0-1.rockspec ]; then
   pushd ${CURRENT_DIR} >/dev/null 2>&1
-  luarocks install tsuru.rockspec
+  sudo luarocks install tsuru-1.0-1.rockspec
   popd >/dev/null 2>&1
 fi


### PR DESCRIPTION
This PR fixes the installation of luarocks and also fixes the default name of the rockspec file that is used to install the dependencies.