### PR TITLE
feature: add yarn support

### DIFF
--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -41,10 +41,11 @@ ln -s $NVM_BIN ~/.nvm_bin
 if [ -f ${CURRENT_DIR}/package.json ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; then
     echo "yarn.lock detected, using yarn to install node packages"
     yarn_bin=$CURRENT_DIR/node_modules/yarn/bin/yarn
+    pushd $CURRENT_DIR
     if [ ! -f $yarn_bin ]; then
         npm install yarn
     fi
-    pushd $CURRENT_DIR && ${yarn_bin} install --production
+    ${yarn_bin} install --production    
     popd
 elif [ -f ${CURRENT_DIR}/package.json ] ; then
     pushd $CURRENT_DIR && npm install --production

--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -38,35 +38,15 @@ rm -f ~/.nvm_bin
 ln -s $NVM_BIN ~/.nvm_bin
 
 
-# yarn install
-download_url="https://yarnpkg.com/latest.tar.gz"
-code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
-if [ "$code" != "200" ]; then
-    echo "Unable to download yarn: $code" && false
-fi
-
-YARN_DIR="${HOME}/.yarn"
-
-rm -rf ${YARN_DIR}
-mkdir -p ${YARN_DIR}
-
-# https://github.com/yarnpkg/yarn/issues/770
-if tar --version | grep -q 'gnu'; then
-    tar xzf /tmp/yarn.tar.gz -C "${YARN_DIR}" --strip 1 --warning=no-unknown-keyword
-else
-    tar xzf /tmp/yarn.tar.gz -C "${YARN_DIR}" --strip 1
-fi
-
-if [ -e ${YARN_DIR} ]; then
-    export PATH="${YARN_DIR}/bin:$PATH"
-fi
-
 if [ -f ${CURRENT_DIR}/package.json ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; then
-    pushd $CURRENT_DIR && yarn install --production
+    echo "yarn.lock detected, using yarn to install node packages"
+    yarn_bin=$CURRENT_DIR/node_modules/yarn/bin/yarn
+    if [ ! -f $yarn_bin ]; then
+        npm install yarn
+    fi
+    pushd $CURRENT_DIR && ${yarn_bin} install --production
     popd
 elif [ -f ${CURRENT_DIR}/package.json ] ; then
     pushd $CURRENT_DIR && npm install --production
     popd
 fi
-
-rm -rf "${YARN_DIR}"

--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -37,7 +37,36 @@ nvm install ${NODE_VERSION}
 rm -f ~/.nvm_bin
 ln -s $NVM_BIN ~/.nvm_bin
 
-if [ -f ${CURRENT_DIR}/package.json ]; then
-	pushd $CURRENT_DIR && npm install --production
-	popd
+
+# yarn install
+download_url="https://yarnpkg.com/latest.tar.gz"
+code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
+if [ "$code" != "200" ]; then
+    echo "Unable to download yarn: $code" && false
 fi
+
+YARN_DIR="${HOME}/.yarn"
+
+rm -rf ${YARN_DIR}
+mkdir -p ${YARN_DIR}
+
+# https://github.com/yarnpkg/yarn/issues/770
+if tar --version | grep -q 'gnu'; then
+    tar xzf /tmp/yarn.tar.gz -C "${YARN_DIR}" --strip 1 --warning=no-unknown-keyword
+else
+    tar xzf /tmp/yarn.tar.gz -C "${YARN_DIR}" --strip 1
+fi
+
+if [ -e ${YARN_DIR} ]; then
+    export PATH="${YARN_DIR}/bin:$PATH"
+fi
+
+if [ -f ${CURRENT_DIR}/package.json ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; then
+    pushd $CURRENT_DIR && yarn install --production
+    popd
+elif [ -f ${CURRENT_DIR}/package.json ] ; then
+    pushd $CURRENT_DIR && npm install --production
+    popd
+fi
+
+rm -rf "${YARN_DIR}"


### PR DESCRIPTION
add yarn support to nodejs platform.

user should add a yarn.lock file to their repository in order to
the deploy to run yarn instead of npm

todo list:
- [x] very basic yarn support
- [ ] support multiple yarn version(using always latest)
- [ ] split yarn install to another helper file