### PR TITLE
modify python3 platform to use venv like on python2 platform

### DIFF
--- a/python3/deploy
+++ b/python3/deploy
@@ -9,13 +9,12 @@ source ${SOURCE_DIR}/base/deploy
 source ${SOURCE_DIR}/base/rc/config
 
 APP_VENV=/home/application/.app_env
-source $APP_VENV/bin/activate
 
 pushd $CURRENT_DIR
 if [ -f ${CURRENT_DIR}/requirements.txt ]; then
-    sudo pip3 install --no-cache-dir -r ${CURRENT_DIR}/requirements.txt
+    $APP_VENV/bin/pip install --no-cache-dir -r ${CURRENT_DIR}/requirements.txt
 elif [ -f ${CURRENT_DIR}/setup.py ]; then
-    sudo pip3 install --no-cache-dir -e ${CURRENT_DIR}/
+    $APP_VENV/bin/pip install --no-cache-dir -e ${CURRENT_DIR}/
 fi
 chown -R ${USER} ${CURRENT_DIR}
 popd

--- a/python3/deploy
+++ b/python3/deploy
@@ -8,11 +8,14 @@ SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/deploy
 source ${SOURCE_DIR}/base/rc/config
 
+APP_VENV=/home/application/.app_env
+source $APP_VENV/bin/activate
+
 pushd $CURRENT_DIR
 if [ -f ${CURRENT_DIR}/requirements.txt ]; then
-    sudo pip3 install -r ${CURRENT_DIR}/requirements.txt
+    sudo pip3 install --no-cache-dir -r ${CURRENT_DIR}/requirements.txt
 elif [ -f ${CURRENT_DIR}/setup.py ]; then
-    sudo pip3 install -e ${CURRENT_DIR}/
+    sudo pip3 install --no-cache-dir -e ${CURRENT_DIR}/
 fi
 chown -R ${USER} ${CURRENT_DIR}
 popd

--- a/python3/install
+++ b/python3/install
@@ -5,13 +5,20 @@
 # license that can be found in the LICENSE file.
 
 SOURCE_DIR=/var/lib/tsuru
+APP_VENV=/home/application/.app_env
 
 source ${SOURCE_DIR}/base/rc/config
 
 add_repository ppa:fkrull/deadsnakes
 apt-get update
-apt-get install python3.5 python3.5-dev git -y
+apt-get install python3.5 python3.5-dev python3.5-venv git -y
 rm -f /usr/bin/python3
 ln -s /usr/bin/python3.5 /usr/bin/python3
 ln -s /usr/bin/python3.5 /usr/bin/python
-curl -sL https://bootstrap.pypa.io/get-pip.py | python3
+
+python3.5 -m venv $APP_VENV
+source $APP_VENV/bin/activate
+$APP_VENV/bin/pip install --upgrade --no-cache-dir pip distribute
+echo "export PATH=${APP_VENV}/bin:\${PATH}" | tee -a ${HOME}/.profile /etc/profile >/dev/null
+echo "Defaults secure_path=\"${APP_VENV}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"" > /etc/sudoers.d/venv
+chown -R ${USER}:${USER} ${APP_VENV}


### PR DESCRIPTION
with the objective of using venv activate like on python2 platform I have made a modification on python3 platform to use venv on python3.5
Also remove messages about pip cache