### PR TITLE
nodejs: Fix yarn to the last working version

### DIFF
--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -51,7 +51,7 @@ if [ -f ${CURRENT_DIR}/package.json ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; then
     echo "yarn.lock detected, using yarn to install node packages"
     yarn_bin=${NVM_BIN}/yarn
     if [ ! -f $yarn_bin ]; then
-        npm install -g yarn
+        npm install -g yarn@0.16.1
     fi
     if [ $NPM_REGISTRY ]; then
         echo "registry \"$NPM_REGISTRY\"" > ~/.yarnrc


### PR DESCRIPTION
The '--prod' flag is making the deploys to randomly fail and the
last versions 0.17.x forces prod mode when 'NODE_ENV=production'.

There's an issue open on the yarn repo (yarnpkg/yarn#1462) about
this problem.