### PR TITLE
Node: You should install only production dependencies as well as npm.

### DIFF
--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -58,7 +58,7 @@ if [ -f ${CURRENT_DIR}/package.json ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; then
         echo "registry \"$NPM_REGISTRY\"" > ~/.yarnrc
         sed -i "s|https://registry.yarnpkg.com|$NPM_REGISTRY|g" ${CURRENT_DIR}/yarn.lock
     fi
-    pushd $CURRENT_DIR && ${yarn_bin} install
+    pushd $CURRENT_DIR && ${yarn_bin} install --production
     popd
 elif [ -f ${CURRENT_DIR}/package.json ] ; then
     pushd $CURRENT_DIR && npm install --production


### PR DESCRIPTION
Hello,

I want to install only the dependencies of production with yarn and it is not possible.
[Yarn info](Https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-production)