### PR TITLE
ensure install scripts run as root

### DIFF
--- a/buildpack/Dockerfile
+++ b/buildpack/Dockerfile
@@ -18,3 +18,4 @@ RUN curl -sLo base-platform.tar.gz https://github.com/tsuru/base-platform/tarbal
 RUN set -ex; \
     sudo /var/lib/tsuru/buildpack/install; \
     sudo rm -rf /var/lib/apt/lists/*
+USER ubuntu

--- a/buildpack/Dockerfile
+++ b/buildpack/Dockerfile
@@ -16,5 +16,5 @@ RUN curl -sLo base-platform.tar.gz https://github.com/tsuru/base-platform/tarbal
     tar -xvf base-platform.tar.gz -C /var/lib/tsuru/base --strip 1; \
     rm -rf base-platform.tar.gz
 RUN set -ex; \
-    /var/lib/tsuru/buildpack/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/buildpack/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/cordova/Dockerfile
+++ b/cordova/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM	tsuru/base-platform
 ADD	. /var/lib/tsuru/cordova
-RUN	cp /var/lib/tsuru/base/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/base/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/cordova/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/cordova/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM	tsuru/base-platform
 ADD	. /var/lib/tsuru/elixir
-RUN	cp /var/lib/tsuru/elixir/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/elixir/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/elixir/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/elixir/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM tsuru/base-platform
 ADD	. /var/lib/tsuru/go
-RUN	cp /var/lib/tsuru/go/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/go/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/go/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/go/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM	tsuru/base-platform
 ADD	. /var/lib/tsuru/java
-RUN	cp /var/lib/tsuru/base/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/base/deploy /var/lib/tsuru
 RUN set -ex; \
-	  /var/lib/tsuru/java/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/java/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM  tsuru/base-platform
 ADD . /var/lib/tsuru/lua
-RUN cp /var/lib/tsuru/lua/deploy /var/lib/tsuru
+RUN sudo cp /var/lib/tsuru/lua/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/lua/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/lua/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM	tsuru/base-platform
 ADD	. /var/lib/tsuru/nodejs
-RUN	cp /var/lib/tsuru/nodejs/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/nodejs/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/nodejs/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/nodejs/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM	tsuru/base-platform
 ADD	. /var/lib/tsuru/perl
-RUN	cp /var/lib/tsuru/perl/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/perl/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/perl/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/perl/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM  tsuru/base-platform
 ADD	. /var/lib/tsuru/php
-RUN	cp /var/lib/tsuru/php/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/php/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/php/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/php/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/play/Dockerfile
+++ b/play/Dockerfile
@@ -4,8 +4,8 @@
 
 FROM	tsuru/base-platform
 ADD	. /var/lib/tsuru/play
-RUN	cp /var/lib/tsuru/play/deploy /var/lib/tsuru
-RUN	chmod -R 777 /var/lib/tsuru/play
+RUN	sudo cp /var/lib/tsuru/play/deploy /var/lib/tsuru
+RUN	sudo chmod -R 777 /var/lib/tsuru/play
 RUN set -ex; \
-    /var/lib/tsuru/play/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/play/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/pypy/Dockerfile
+++ b/pypy/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM	tsuru/base-platform
 ADD	. /var/lib/tsuru/pypy
-RUN	cp /var/lib/tsuru/pypy/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/pypy/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/pypy/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/pypy/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -4,9 +4,9 @@
 
 FROM tsuru/base-platform
 ADD . /var/lib/tsuru/python
-RUN cp /var/lib/tsuru/python/deploy /var/lib/tsuru
+RUN sudo cp /var/lib/tsuru/python/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/python/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/python/install; \
+    sudo rm -rf /var/lib/apt/lists/*
 ENV PYENV_ROOT="/var/lib/pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM	tsuru/base-platform
 ADD	. /var/lib/tsuru/ruby
-RUN	cp /var/lib/tsuru/ruby/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/ruby/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/ruby/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/ruby/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM	tsuru/base-platform
 ADD	. /var/lib/tsuru/static
-RUN	cp /var/lib/tsuru/static/deploy /var/lib/tsuru
+RUN	sudo cp /var/lib/tsuru/static/deploy /var/lib/tsuru
 RUN set -ex; \
-    /var/lib/tsuru/static/install; \
-    rm -rf /var/lib/apt/lists/*
+    sudo /var/lib/tsuru/static/install; \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/tests/Dockerfile.template
+++ b/tests/Dockerfile.template
@@ -5,8 +5,8 @@
 FROM platform-{PLATFORM}
 WORKDIR /tests
 ADD . /tests
-ADD common/* /tests/common
+ADD common/* /tests/common/
 ADD https://github.com/sstephenson/bats/archive/master.tar.gz .
-RUN mkdir ./bin && tar -zxf master.tar.gz && ./bats-master/install.sh .
-RUN echo "echo 'ran base deploy'" > /var/lib/tsuru/base/deploy
-RUN bin/bats common && bin/bats .
+RUN sudo mkdir ./bin && sudo tar -zxf master.tar.gz && sudo ./bats-master/install.sh .
+RUN echo "echo 'ran base deploy'" | sudo tee /var/lib/tsuru/base/deploy
+RUN sudo bin/bats common && sudo bin/bats .


### PR DESCRIPTION
This is necessary if we are to change the default user in the base platform.

Also this sets the USER ubuntu in the buildpack dockerfile since it doesn't use the base platform.