### PR TITLE
nodejs: fix yarn install error treatment

### DIFF
--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -61,11 +61,17 @@ if [ -f "${CURRENT_DIR}/package.json" ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; th
     pushd $CURRENT_DIR
     set +e
     exec 9>&1
-    YARN_OUTPUT=`${yarn_bin} install --non-interactive 2>&1 | tee /dev/fd/9`
-    STATUS=$?
+    TMPFILE=`mktemp`
+    YARN_OUTPUT=`${yarn_bin} install --non-interactive 2>&1 | tee /dev/fd/9; echo ${PIPESTATUS[0]} > $TMPFILE`
+    STATUS=`cat $TMPFILE 2>/dev/null || echo 1`
     set -e
-    if [ $STATUS -ne 0 ] && [[ $YARN_OUTPUT =~ ^.*unknown\ option.*--non-interactive.*$ ]]; then
-      ${yarn_bin} install
+    if [ $STATUS -ne 0 ]; then
+      if [[ $YARN_OUTPUT =~ ^.*unknown\ option.*--non-interactive.*$ ]]; then
+        # If --non-interactive flag is not available (older yarn versions), falls back to the default install command
+        ${yarn_bin} install
+      else
+        exit $STATUS
+      fi
     fi
     popd
 elif [ -f ${CURRENT_DIR}/package.json ] ; then

--- a/tests/nodejs/tests.bats
+++ b/tests/nodejs/tests.bats
@@ -61,7 +61,29 @@ EOF
     [[ "$output" == *"0.24.6"* ]]
 }
 
-@test "works with versions without support to --non-interactive flag" {
+@test "breaks with invalid dependencies" {
+    cat <<EOF>>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "express": "999"
+  },
+  "engines": {
+      "yarn": "0.24.6"
+  }
+}
+EOF
+
+    touch ${CURRENT_DIR}/yarn.lock
+    run /var/lib/tsuru/deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Couldn't find any versions for \"express\" that matches \"999\""* ]]
+}
+
+@test "works with yarn versions without support to --non-interactive flag" {
     cat <<EOF>>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",


### PR DESCRIPTION
PR #50 introduced a bug in nodejs platform. Errors in `yarn install --non-interactive` were being ignored.