### PR TITLE
static/install: use latest nginx

### DIFF
--- a/static/install
+++ b/static/install
@@ -8,6 +8,9 @@ SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/rc/config
 
 apt-get update
+apt-get install -y --no-install-recommends software-properties-common
+add-apt-repository -y ppa:nginx/stable
+apt-get update
 apt-get install -y --no-install-recommends nginx
 
 rm -rf /var/log/nginx /var/lib/nginx


### PR DESCRIPTION
Since the platform uses Ubuntu 14.04, the latest nginx available there
is too old (1.4). Using the ppa, we can get nginx 1.12.