### PR TITLE
nodejs: improve nvm error handling

### DIFF
--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -40,9 +40,24 @@ fi
 export NVM_DIR=${HOME}/.nvm
 [ ! -e ${NVM_DIR} ] && mkdir -p ${NVM_DIR}
 
+set +e
 . /etc/nvm/nvm.sh
+nvm_source_exit_code="$?"
+set -e
 
-nvm install ${NODE_VERSION}
+if [[ "$nvm_source_exit_code" != "0" ]]; then
+    echo "WARNING: sourcing nvm.sh returned exit status ${nvm_source_exit_code}. This may not be a problem but report this message if the deploy fails."
+fi
+
+set +e
+nvm install "${NODE_VERSION}"
+nvm_install_exit_code="$?"
+set -e
+
+if [[ "$nvm_install_exit_code" != "0" ]]; then
+    echo "ERROR: \`nvm install \"${NODE_VERSION}\"\` returned exit status ${nvm_install_exit_code}."
+    exit "${nvm_install_exit_code}"
+fi
 
 rm -f ~/.nvm_bin
 ln -s $NVM_BIN ~/.nvm_bin

--- a/nodejs/install
+++ b/nodejs/install
@@ -7,11 +7,7 @@
 SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/rc/config
 
-apt-get update
-apt-get install -y --no-install-recommends git
-
-git clone https://github.com/creationix/nvm.git /etc/nvm
-cd /etc/nvm && git checkout `git describe --abbrev=0 --tags`
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.7/install.sh | NVM_DIR=/etc/nvm bash
 
 cat >> ${HOME}/.profile <<EOF
 if [ -e ${HOME}/.nvm_bin ]; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -8,8 +8,11 @@ parent_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
 
 cd "$parent_path"
 
+has_parallel=$(which parallel)
+
 if [ ! -z $1 ]; then
     platforms=$1
+    has_parallel=""
 else
     platforms=$(ls -d */ | cut -f1 -d'/' | grep -v common)
 fi
@@ -28,8 +31,6 @@ function run_test {
     rm ./$plat/Dockerfile && rm -rf ./$plat/common
 }
 export -f run_test
-
-has_parallel=$(which parallel)
 
 for plat in $platforms; do
     if [ "${has_parallel}" ]; then


### PR DESCRIPTION
Running nvm with `set -e` causes error messages to be swallowed because
the script exits before the error message is printed. Now we allow
errors while running nvm and only exit after we've handled the error ourselves.

Now the error of a invalid nodejs version looks like:

```
$ tsuru app-deploy . -a myapp
Uploading files (0.00MB)... 100.00% Processing. ok
ERROR: `nvm install ">=v8.9.3"` returned exit status 3.
Version '>=v8.9.3' not found - try `nvm ls-remote` to browse available versions.
error running "/var/lib/tsuru/deploy archive file:///home/application/archive.tar.gz": exit status 3
Exit status 1
```

Related to #54