### PR TITLE
python: force pyenv rehash after installing dependencies with pipenv

### DIFF
--- a/python/deploy
+++ b/python/deploy
@@ -56,6 +56,7 @@ if [ -f "${CURRENT_DIR}/Pipfile.lock" ]; then
     echo "Pipfile.lock detected, using 'pipenv install --system --deploy' to install dependencies"
     pip install pipenv
     pipenv install --system --deploy
+    pyenv rehash
 elif [ -f "${CURRENT_DIR}/requirements.txt" ]; then
     echo "requirements.txt detected, using 'pip install -r ./requirements.txt' to install dependencies"
     pip install -r ./requirements.txt


### PR DESCRIPTION
While testing sometimes pyenv would not create shims for dependencies
with bins. This is hard to reproduce but forcing a pyenv rehash seems to
work as it'll create all missing shims.