### PR TITLE
nodejs: ignore production flag when NPM_CONFIG_PRODUCTION env var is set

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -35,5 +35,8 @@ You have to list your dependencies in the `package.json` file.
     }
     ...
 
+If you want to also install development dependencies, set the environment
+variable ``NPM_CONFIG_PRODUCTION=false``. Otherwise, we'll only install
+regular dependencies.
 You can also cache your node_modules by setting environment variable
 ``KEEP_NODE_MODULES=true``.

--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -62,6 +62,13 @@ fi
 rm -f ~/.nvm_bin
 ln -s $NVM_BIN ~/.nvm_bin
 
+# Set --production flag only if NPM_CONFIG_PRODUCTION env var is not set
+if [ -z "$NPM_CONFIG_PRODUCTION" ]; then
+  PRODUCTION_FLAG="--production"
+else
+  PRODUCTION_FLAG=""
+fi
+
 if [ -f "${CURRENT_DIR}/package.json" ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; then
     echo "yarn.lock detected, using yarn to install node packages"
     YARN_DEFAULT_VERSION="1.3.2"
@@ -78,19 +85,19 @@ if [ -f "${CURRENT_DIR}/package.json" ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; th
     set +e
     exec 9>&1
     TMPFILE=`mktemp`
-    YARN_OUTPUT=`${yarn_bin} install --production --non-interactive 2>&1 | tee /dev/fd/9; echo ${PIPESTATUS[0]} > $TMPFILE`
+    YARN_OUTPUT=`${yarn_bin} install ${PRODUCTION_FLAG} --non-interactive 2>&1 | tee /dev/fd/9; echo ${PIPESTATUS[0]} > $TMPFILE`
     STATUS=`cat $TMPFILE 2>/dev/null || echo 1`
     set -e
     if [ $STATUS -ne 0 ]; then
       if [[ $YARN_OUTPUT =~ ^.*unknown\ option.*--non-interactive.*$ ]]; then
         # If --non-interactive flag is not available (older yarn versions), falls back to the default install command
-        ${yarn_bin} install
+        ${yarn_bin} install ${PRODUCTION_FLAG}
       else
         exit $STATUS
       fi
     fi
     popd
 elif [ -f ${CURRENT_DIR}/package.json ] ; then
-    pushd $CURRENT_DIR && npm install --production
+    pushd $CURRENT_DIR && npm install ${PRODUCTION_FLAG}
     popd
 fi

--- a/tests/nodejs/tests.bats
+++ b/tests/nodejs/tests.bats
@@ -153,3 +153,97 @@ EOF
     [[ "$output" == *"Version 'myinvalidversion' not found"* ]]
     [[ "$output" == *"ERROR: \`nvm install \"myinvalidversion\"\` returned exit status"* ]]
 }
+
+@test "doesn't install dev dependencies with npm" {
+    cat <<EOF>>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "is-sorted": "1.x"
+  },
+  "devDependencies": {
+    "leftpad": "0.0.1"
+  }
+}
+EOF
+
+    run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+
+    [ -d ${CURRENT_DIR}/node_modules/is-sorted ]
+    [ ! -d ${CURRENT_DIR}/node_modules/leftpad ]
+}
+
+@test "doesn't install dev dependencies with yarn" {
+    cat <<EOF>>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "is-sorted": "1.x"
+  },
+  "devDependencies": {
+    "leftpad": "0.0.1"
+  }
+}
+EOF
+
+    touch ${CURRENT_DIR}/yarn.lock
+    run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+
+    [ -d ${CURRENT_DIR}/node_modules/is-sorted ]
+    [ ! -d ${CURRENT_DIR}/node_modules/leftpad ]
+}
+
+@test "installs dev dependencies with npm and NPM_CONFIG_PRODUCTION=false" {
+    cat <<EOF>>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "is-sorted": "1.x"
+  },
+  "devDependencies": {
+    "leftpad": "0.0.1"
+  }
+}
+EOF
+
+    NPM_CONFIG_PRODUCTION=false run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+
+    [ -d ${CURRENT_DIR}/node_modules/is-sorted ]
+    [ -d ${CURRENT_DIR}/node_modules/leftpad ]
+}
+
+@test "installs dev dependencies with yarn and NPM_CONFIG_PRODUCTION=false" {
+    cat <<EOF>>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "is-sorted": "1.x"
+  },
+  "devDependencies": {
+    "leftpad": "0.0.1"
+  }
+}
+EOF
+
+    touch ${CURRENT_DIR}/yarn.lock
+    NPM_CONFIG_PRODUCTION=false run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+
+    [ -d ${CURRENT_DIR}/node_modules/is-sorted ]
+    [ -d ${CURRENT_DIR}/node_modules/leftpad ]
+}

--- a/tests/nodejs/tests.bats
+++ b/tests/nodejs/tests.bats
@@ -201,6 +201,53 @@ EOF
     [ ! -d ${CURRENT_DIR}/node_modules/leftpad ]
 }
 
+@test "doesn't install dev dependencies with npm and NPM_CONFIG_PRODUCTION=true" {
+    cat <<EOF>>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "is-sorted": "1.x"
+  },
+  "devDependencies": {
+    "leftpad": "0.0.1"
+  }
+}
+EOF
+
+    NPM_CONFIG_PRODUCTION=true run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+
+    [ -d ${CURRENT_DIR}/node_modules/is-sorted ]
+    [ ! -d ${CURRENT_DIR}/node_modules/leftpad ]
+}
+
+@test "doesn't install dev dependencies with yarn and NPM_CONFIG_PRODUCTION=true" {
+    cat <<EOF>>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "is-sorted": "1.x"
+  },
+  "devDependencies": {
+    "leftpad": "0.0.1"
+  }
+}
+EOF
+
+    touch ${CURRENT_DIR}/yarn.lock
+    NPM_CONFIG_PRODUCTION=true run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+
+    [ -d ${CURRENT_DIR}/node_modules/is-sorted ]
+    [ ! -d ${CURRENT_DIR}/node_modules/leftpad ]
+}
+
 @test "installs dev dependencies with npm and NPM_CONFIG_PRODUCTION=false" {
     cat <<EOF>>${CURRENT_DIR}/package.json
 {


### PR DESCRIPTION
Since #44, `--production` flag is always set in yarn or npm. With this, it ignores `NPM_CONFIG_PRODUCTION` env var and doesn't install dev dependencies.

With this PR, we only set this flag if `NPM_CONFIG_PRODUCTION` env var is undefined. Now it's possible to set `NPM_CONFIG_PRODUCTION=false` to also install dev dependencies.