### PR TITLE
Adding pypy2 and pypy3 to python platform

### DIFF
--- a/python/install
+++ b/python/install
@@ -7,7 +7,7 @@
 SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/rc/config
 
-PY_VERSIONS="2.7.13 3.5.3 3.6.1 3.6.2"
+PY_VERSIONS="2.7.13 3.5.3 3.6.1 3.6.2 pypy2.7-5.10.0 pypy3.5-5.10.0"
 PYENV_ROOT="/var/lib/pyenv"
 
 apt-get update


### PR DESCRIPTION
This PR allows users of the python platform to use modern versions of the pypy platform, both pypy2 as well as pypy3.