### PR TITLE
[WIP] python: update defaults to 2.7.14, 3.5.4, 3.6.4

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,23 +1,19 @@
 # Python platform
 
-The Python platform uses python 2.7.13 by default and get your dependencies with pip,
+The Python platform uses python 2.7.14 by default and get your dependencies with pip,
 either ``requirements.txt`` or ``setup.py``.
 
 You can define which python version you want using ``.python-version``, always use full versions.
 
 ex:
 ```
-3.6.1
+3.6.4
 ```
 
 available python versions:
-- 2.7.13
-- 3.5.3
-- 3.6.1
-- 3.6.2
-
-when adding new releases, we will retain previous version on the series to allow time for users update their apps.
-e,g: when 3.6.3 is released, we will remove 3.6.1.
+- 2.7.14
+- 3.5.4
+- 3.6.4
 
 
 ## Code deployment

--- a/python/deploy
+++ b/python/deploy
@@ -9,7 +9,7 @@ source ${SOURCE_DIR}/base/deploy
 source ${SOURCE_DIR}/base/rc/config
 
 #find apps python version
-python_version_default="2.7.13"
+python_version_default="2.7.14"
 version_origin="default"
 
 if [ -n "${PYTHON_VERSION}" ]; then
@@ -30,7 +30,16 @@ if ! pyenv versions | grep -E " ${PYTHON_VERSION}(\s|$)" >/dev/null; then
     echo "Python version '${PYTHON_VERSION}' (${version_origin}) is not supported."
     echo "Valid python versions are:"
     pyenv versions --skip-aliases --bare | grep -v "/env"
-    PYTHON_VERSION="${python_version_default}"
+    case $PYTHON_VERSION in
+        3.6*)
+            PYTHON_VERSION="3.6.4"
+            ;;
+        3.5*)
+            PYTHON_VERSION="3.5.4"
+            ;;
+        *)
+            PYTHON_VERSION=${python_version_default}
+    esac
     version_origin="default"
 fi
 

--- a/python/install
+++ b/python/install
@@ -7,7 +7,7 @@
 SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/rc/config
 
-PY_VERSIONS="2.7.13 3.5.3 3.6.1 3.6.2 pypy2.7-5.10.0 pypy3.5-5.10.0"
+PY_VERSIONS="2.7.14 3.5.4 3.6.4 pypy2.7-5.10.0 pypy3.5-5.10.0"
 PYENV_ROOT="/var/lib/pyenv"
 
 apt-get update
@@ -33,7 +33,7 @@ export CFLAGS='-O2'
 
 for pyversion in $PY_VERSIONS; do (pyenv install $pyversion); done
 
-pyenv global 2.7.13
+pyenv global 2.7.14
 
 chown -R ${USER}:${USER} $PYENV_ROOT
 

--- a/tests/python/tests.bats
+++ b/tests/python/tests.bats
@@ -16,7 +16,7 @@ setup() {
 
 @test "use python version 2.7 as default" {
     run /var/lib/tsuru/deploy
-    [[ "$output" == *"Using python version: 2.7.13 (default)"* ]]
+    [[ "$output" == *"Using python version: 2.7.14 (default)"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
@@ -40,9 +40,23 @@ setup() {
 }
 
 @test "parse python version from PYTHON_VERSION" {
-    export PYTHON_VERSION=3.6.1
+    export PYTHON_VERSION=3.6.4
     run /var/lib/tsuru/deploy
     [[ "$output" == *"Using python version: 3.6.1 (PYTHON_VERSION environment variable)"* ]]
+
+    pushd ${CURRENT_DIR}
+    run python --version
+    popd
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"3.6"* ]]
+    unset PYTHON_VERSION
+}
+
+@test "find nearest python version if possible" {
+    export PYTHON_VERSION=3.6.1
+    run /var/lib/tsuru/deploy
+    [[ "$output" == *"Using python version: 3.6.4 (default)"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
@@ -57,7 +71,7 @@ setup() {
     echo "xyz" > ${CURRENT_DIR}/.python-version
     run /var/lib/tsuru/deploy
     [[ "$output" == *"Python version 'xyz' (.python-version file) is not supported"* ]]
-    [[ "$output" == *"Using python version: 2.7.13 (default)"* ]]
+    [[ "$output" == *"Using python version: 2.7.14 (default)"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
@@ -71,7 +85,7 @@ setup() {
     export PYTHON_VERSION=abc
     run /var/lib/tsuru/deploy
     [[ "$output" == *"Python version 'abc' (PYTHON_VERSION environment variable) is not supported"* ]]
-    [[ "$output" == *"Using python version: 2.7.13 (default)"* ]]
+    [[ "$output" == *"Using python version: 2.7.14 (default)"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version


### PR DESCRIPTION
to avoid supporting too much versions created a snippet to find the nearest plausible python version.

i.e. user ask for python 3.6.1, we will use 3.6.4.

only applied to 3.5 and 3.6 series.

otherwise we go back to 2.7 series default.