### PR TITLE
go: make $HOME/.profile compatible with /bin/sh

### DIFF
--- a/go/install
+++ b/go/install
@@ -21,7 +21,7 @@ echo "GOPATH=${APP_DIR}" >> ${HOME}/.profile
 echo 'PATH=$GOPATH:$PATH' >> ${HOME}/.profile
 echo 'export PATH GOPATH' >> ${HOME}/.profile
 echo 'export GIMME_SILENT_ENV=1' >> ${HOME}/.profile
-echo '[ -f ${HOME}/.gimme/envs/latest.env ] && source ${HOME}/.gimme/envs/latest.env' >> ${HOME}/.profile
+echo '[ -f ${HOME}/.gimme/envs/latest.env ] && . ${HOME}/.gimme/envs/latest.env' >> ${HOME}/.profile
 
 sudo -u ubuntu mkdir -p ${HOME}/.gimme/versions
 GO_VERSIONS="stable"


### PR DESCRIPTION
`source` is a `bash` exclusive builtin. Using `.` make the script
compatible with `sh`.

This fixes the error message `sh: 27: source: not found` during deploys.