### PR TITLE
python: provide --process-dependency-links to pip install

### DIFF
--- a/python/deploy
+++ b/python/deploy
@@ -84,6 +84,6 @@ elif [ -f "${CURRENT_DIR}/requirements.txt" ]; then
     pip install -r ./requirements.txt
 elif [ -f "${CURRENT_DIR}/setup.py" ]; then
     echo "setup.py detected, using 'pip install -e .' to install dependencies"
-    pip install -e .
+    pip install --process-dependency-links -e .
 fi
 popd


### PR DESCRIPTION
setup.py files can specify dependency_links which point to alternative
location for packages. It's useful for legacy deployments on hybrid
environments that contain private packages on private git/hg repos.

This is a deprecated feature that has not been replaced yet ¯\_(ツ)_/¯,
so let's keep using it? x)))