### PR TITLE
nodejs: fix regexp in deploy script

### DIFF
--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -79,8 +79,8 @@ if [ -f "${CURRENT_DIR}/package.json" ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; th
     fi
     if [ $NPM_REGISTRY ]; then
         echo "registry \"$NPM_REGISTRY\"" > ~/.yarnrc
-        sed -i "s|https?://registry.yarnpkg.com|$NPM_REGISTRY|g" ${CURRENT_DIR}/yarn.lock
-        sed -i "s|https?://registry.npmjs.org|$NPM_REGISTRY|g" ${CURRENT_DIR}/yarn.lock
+        sed -i -E "s|https?://registry.yarnpkg.com|$NPM_REGISTRY|g" ${CURRENT_DIR}/yarn.lock
+        sed -i -E "s|https?://registry.npmjs.org|$NPM_REGISTRY|g" ${CURRENT_DIR}/yarn.lock
     fi
     pushd $CURRENT_DIR
     set +e
@@ -100,7 +100,7 @@ if [ -f "${CURRENT_DIR}/package.json" ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; th
     popd
 elif [ -f ${CURRENT_DIR}/package.json ] ; then
     if [ -f "${CURRENT_DIR}/package-lock.json" ]; then
-    	sed -i "s|https?://registry.npmjs.org|$NPM_REGISTRY|g" ${CURRENT_DIR}/package-lock.json
+    	sed -i -E "s|https?://registry.npmjs.org|$NPM_REGISTRY|g" ${CURRENT_DIR}/package-lock.json
     fi
     pushd $CURRENT_DIR && npm install ${PRODUCTION_FLAG}
     popd

--- a/tests/nodejs/tests.bats
+++ b/tests/nodejs/tests.bats
@@ -294,3 +294,43 @@ EOF
     [ -d ${CURRENT_DIR}/node_modules/is-sorted ]
     [ -d ${CURRENT_DIR}/node_modules/leftpad ]
 }
+
+@test "replaces the default npmjs.org urls with NPM_REGISTRY" {
+    cat <<EOF>>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "express": "3.x"
+  }
+}
+EOF
+    cat <<EOF>>${CURRENT_DIR}/package-lock.json
+https://registry.npmjs.org/express
+EOF
+    export NPM_REGISTRY=my-registry.example.com
+    run /var/lib/tsuru/deploy
+    [ `cat ${CURRENT_DIR}/package-lock.json` == "my-registry.example.com/express" ]
+}
+
+@test "replaces the default yarnpkg.com urls with NPM_REGISTRY" {
+    cat <<EOF>>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "express": "3.x"
+  }
+}
+EOF
+    cat <<EOF>>${CURRENT_DIR}/yarn.lock
+https://registry.yarnpkg.com/express
+EOF
+    export NPM_REGISTRY=my-registry.example.com
+    run /var/lib/tsuru/deploy
+    [ `cat ${CURRENT_DIR}/yarn.lock` == "my-registry.example.com/express" ]
+}


### PR DESCRIPTION
This fixes npm and yarn registry URLs replacement with `$NPM_REGISTRY`.