### PR TITLE
ruby: always check bundler version even when not changed ruby version

### DIFF
--- a/ruby/deploy
+++ b/ruby/deploy
@@ -73,16 +73,16 @@ if [ "$INSTALL_RUBY" == "1" ]; then
         fi
         exit 1
     fi
+fi
 
-    BUNDLER_VERSION=$(get_bundler_version $RUBY_VERSION)
-    if [ "$BUNDLER_VERSION" != "" ]; then
-        gem uninstall bundler
-        if [ -z "$GEM_SOURCE" ]; then
-            gem instal bundler --no-ri --no-rdoc -v "$BUNDLER_VERSION"
-        else
-            echo "-- Using $GEM_SOURCE as remote gem source --"
-            gem install --clear-sources --no-ri --no-rdoc --source=$GEM_SOURCE bundler -v "$BUNDLER_VERSION"
-        fi
+BUNDLER_VERSION=$(get_bundler_version $RUBY_VERSION)
+if [ "$BUNDLER_VERSION" != "" ]; then
+    gem uninstall bundler
+    if [ -z "$GEM_SOURCE" ]; then
+        gem instal bundler --no-ri --no-rdoc -v "$BUNDLER_VERSION"
+    else
+        echo "-- Using $GEM_SOURCE as remote gem source --"
+        gem install --clear-sources --no-ri --no-rdoc --source=$GEM_SOURCE bundler -v "$BUNDLER_VERSION"
     fi
 fi
 


### PR DESCRIPTION
If ruby is already on desired version, bundler will not be installed even when necessary