### PR TITLE
Fix a problem related to the pip param

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM tsuru/base-platform:18.04
+FROM tsuru/base-platform
 COPY ./install /var/lib/tsuru/python/
 RUN set -ex; \
     sudo /var/lib/tsuru/python/install; \

--- a/python/install
+++ b/python/install
@@ -10,8 +10,6 @@ source ${SOURCE_DIR}/base/rc/config
 PY_VERSIONS="2.7.14 3.5.5 3.6.5 pypy2.7-5.10.0 pypy3.5-5.10.1"
 PYENV_ROOT="/var/lib/pyenv"
 
-export DEBIAN_FRONTEND=noninteractive
-
 apt-get update
 apt-get install -y --no-install-recommends \
     make build-essential libssl-dev zlib1g-dev libbz2-dev \
@@ -47,7 +45,7 @@ apt-get remove --purge -y \
 
 apt-get install -y --no-install-recommends \
         libssl1.0.0 zlib1g libbz2-1.0 \
-        libsqlite3-0 libncurses5 \
-        libncursesw5 libreadline7
+        libreadline6 libsqlite3-0 libncurses5 \
+        libncursesw5
 
 apt-get autoremove -y


### PR DESCRIPTION
Return to the 14.04 version of ubuntu to fix a problem related to the missing parameter process-dependency-links of pip which was removed from version 19.0