### PR TITLE
python: add support to version 3.7.4

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -14,6 +14,7 @@ available python versions:
 - 2.7.14
 - 3.5.5
 - 3.6.5
+- 3.7.4
 - pypy2.7-5.10.0
 - pypy3.5-5.10.1
 

--- a/python/install
+++ b/python/install
@@ -7,7 +7,7 @@
 SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/rc/config
 
-PY_VERSIONS="2.7.14 3.5.5 3.6.5 pypy2.7-5.10.0 pypy3.5-5.10.1"
+PY_VERSIONS="2.7.14 3.5.5 3.6.5 3.7.4 pypy2.7-5.10.0 pypy3.5-5.10.1"
 PYENV_ROOT="/var/lib/pyenv"
 
 export DEBIAN_FRONTEND=noninteractive
@@ -16,7 +16,7 @@ apt-get update
 apt-get install -y --no-install-recommends \
     make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev git libexpat1
+    xz-utils tk-dev git libexpat1 libffi-dev
 
 git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT}
 git clone https://github.com/pyenv/pyenv-virtualenv.git ${PYENV_ROOT}/plugins/pyenv-virtualenv
@@ -43,7 +43,7 @@ apt-get remove --purge -y \
         libssl-dev zlib1g-dev libbz2-dev \
         libreadline-dev libsqlite3-dev llvm \
         libncurses5-dev libncursesw5-dev \
-        tk-dev git
+        tk-dev git libffi-dev
 
 apt-get install -y --no-install-recommends \
         libssl1.0.0 zlib1g libbz2-1.0 \


### PR DESCRIPTION
As the title says, this installs the python version 3.7.4 and the dev dependency needed to build `libffi-dev`.