### PR TITLE
nodejs: Preserve node modules if dependencies were not updated

### DIFF
--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -7,8 +7,60 @@
 SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/rc/config
 
-if [ -n "${KEEP_NODE_MODULES}" ] && [ -d ${CURRENT_DIR}/node_modules ]; then
-	PLATFORM_EXTRA_RSYNC_ARGS="--filter \"protect node_modules/\""
+function calculate_deps_hash() {
+    local basepath=$1
+    set +e
+    pushd ${basepath} >/dev/null
+    tail -n +1 \
+        ./package.json \
+        ./package-lock.json \
+        ./yarn.lock \
+        2>/dev/null | sha256sum | awk '{print $1}'
+    popd >/dev/null
+    set -e
+}
+
+function archive_deps_hash() {
+    if [[ ! -f /home/application/archive.tar.gz ]]; then
+        return
+    fi
+    tmpdir=$(mktemp -d)
+    trap "rm -rf ${tmpdir}" EXIT
+    set +e
+    tar -C ${tmpdir} -xzf /home/application/archive.tar.gz package.json package-lock.json yarn.lock 2>/dev/null
+    set -e
+    calculate_deps_hash ${tmpdir}
+}
+
+function track_deps() {
+    mkdir -p /home/application/nodejs
+    set +e
+    cp ${CURRENT_DIR}/package.json \
+        ${CURRENT_DIR}/package-lock.json \
+        ${CURRENT_DIR}/yarn.lock \
+        /home/application/nodejs/ \
+        2>/dev/null
+    set -e
+}
+
+# If dependency files didn't change it's safe for us to protect the
+# `node_modules` directory from being removed by rsync. If dependency files
+# were updated it's safer to remove node_modules and reinstall everything.
+if [[ -d ${CURRENT_DIR}/node_modules ]]; then
+    old_deps_hash=$(calculate_deps_hash /home/application/nodejs)
+    new_deps_hash=$(archive_deps_hash)
+
+    if  [[ "${old_deps_hash}" == "${new_deps_hash}" ]]; then
+        keep=1
+        reason="Dependency files hash match"
+    elif [[ -n "${KEEP_NODE_MODULES}" ]] ; then
+        keep=1
+        reason="Environment variable \$KEEP_NODE_MODULES is set"
+    fi
+    if [[ $keep == 1 ]]; then
+        echo "${reason}, preserving old node_modules directory."
+        PLATFORM_EXTRA_RSYNC_ARGS='--filter "protect node_modules/"'
+    fi
 fi
 
 source ${SOURCE_DIR}/base/deploy
@@ -59,6 +111,8 @@ if [[ "$nvm_install_exit_code" != "0" ]]; then
     exit "${nvm_install_exit_code}"
 fi
 
+nvm cache clear
+
 rm -f ~/.nvm_bin
 ln -s $NVM_BIN ~/.nvm_bin
 
@@ -69,12 +123,23 @@ else
   PRODUCTION_FLAG=""
 fi
 
+track_deps
+
 if [ -f "${CURRENT_DIR}/package.json" ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; then
     echo "yarn.lock detected, using yarn to install node packages"
-    YARN_DEFAULT_VERSION="1.3.2"
+    YARN_DEFAULT_VERSION="1.21.1"
     yarn_bin=${NVM_BIN}/yarn
     if [ ! -f $yarn_bin ]; then
-    	YARN_VERSION=`CURRENT_DIR=${CURRENT_DIR} node -e 'var pkg = require(process.env.CURRENT_DIR+"/package.json"); console.log((pkg.engines && pkg.engines.yarn) ? pkg.engines.yarn.replace(" ", "") : "'${YARN_DEFAULT_VERSION}'")'`
+        package_version=$(node -e "
+        var pkg = require('${CURRENT_DIR}/package.json');
+        var options = ['engines', 'dependencies', 'devDependencies'];
+        for (var o of options) {
+            if (pkg[o] && pkg[o].yarn) {
+                console.log(pkg[o].yarn);
+                break;
+            }
+        }")
+        YARN_VERSION=${package_version:-$YARN_DEFAULT_VERSION}
         npm install -g yarn@${YARN_VERSION}
     fi
     if [ $NPM_REGISTRY ]; then
@@ -97,11 +162,14 @@ if [ -f "${CURRENT_DIR}/package.json" ] && [ -f "${CURRENT_DIR}/yarn.lock" ]; th
         exit $STATUS
       fi
     fi
+    yarn cache clean || true
     popd
 elif [ -f ${CURRENT_DIR}/package.json ] ; then
     if [ -f "${CURRENT_DIR}/package-lock.json" ]; then
-    	sed -i -E "s|https?://registry.npmjs.org|$NPM_REGISTRY|g" ${CURRENT_DIR}/package-lock.json
+        sed -i -E "s|https?://registry.npmjs.org|$NPM_REGISTRY|g" ${CURRENT_DIR}/package-lock.json
     fi
-    pushd $CURRENT_DIR && npm install ${PRODUCTION_FLAG}
+    pushd $CURRENT_DIR
+    npm install ${PRODUCTION_FLAG}
+    npm cache clean --force || true
     popd
 fi

--- a/tests/nodejs/tests.bats
+++ b/tests/nodejs/tests.bats
@@ -14,8 +14,8 @@ setup() {
     rm -rf /home/ubuntu/.nvm
 }
 
-@test "defaults yarn 1.3.2 if yarn.lock present" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+@test "defaults yarn 1.21.1 if yarn.lock present" {
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -33,11 +33,11 @@ EOF
     [[ "$output" == *"yarn.lock detected, using yarn to install node packages"* ]]
 
     run /home/ubuntu/.nvm_bin/yarn --version
-    [[ "$output" == *"1.3.2"* ]]
+    [[ "$output" == *"1.21.1"* ]]
 }
 
 @test "installs yarn from package.json" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -61,8 +61,31 @@ EOF
     [[ "$output" == *"0.24.6"* ]]
 }
 
+@test "installs yarn from dependencies in package.json" {
+    cat <<EOF >>${CURRENT_DIR}/package.json
+{
+  "name": "hello-world",
+  "description": "hello world test on tsuru",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "express": "3.x",
+    "yarn": "0.24.6"
+  }
+}
+EOF
+
+    touch ${CURRENT_DIR}/yarn.lock
+    run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"yarn.lock detected, using yarn to install node packages"* ]]
+
+    run /home/ubuntu/.nvm_bin/yarn --version
+    [[ "$output" == *"0.24.6"* ]]
+}
+
 @test "breaks with invalid dependencies" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -84,7 +107,7 @@ EOF
 }
 
 @test "works with yarn versions without support to --non-interactive flag" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -127,7 +150,7 @@ EOF
 }
 
 @test "reads node version from package.json" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -155,7 +178,7 @@ EOF
 }
 
 @test "doesn't install dev dependencies with npm" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -178,7 +201,7 @@ EOF
 }
 
 @test "doesn't install dev dependencies with yarn" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -202,7 +225,7 @@ EOF
 }
 
 @test "doesn't install dev dependencies with npm and NPM_CONFIG_PRODUCTION=true" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -225,7 +248,7 @@ EOF
 }
 
 @test "doesn't install dev dependencies with yarn and NPM_CONFIG_PRODUCTION=true" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -249,7 +272,7 @@ EOF
 }
 
 @test "installs dev dependencies with npm and NPM_CONFIG_PRODUCTION=false" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -272,7 +295,7 @@ EOF
 }
 
 @test "installs dev dependencies with yarn and NPM_CONFIG_PRODUCTION=false" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -296,7 +319,7 @@ EOF
 }
 
 @test "replaces the default npmjs.org urls with NPM_REGISTRY" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -307,7 +330,7 @@ EOF
   }
 }
 EOF
-    cat <<EOF>>${CURRENT_DIR}/package-lock.json
+    cat <<EOF >>${CURRENT_DIR}/package-lock.json
 https://registry.npmjs.org/express
 EOF
     export NPM_REGISTRY=my-registry.example.com
@@ -316,7 +339,7 @@ EOF
 }
 
 @test "replaces the default yarnpkg.com urls with NPM_REGISTRY" {
-    cat <<EOF>>${CURRENT_DIR}/package.json
+    cat <<EOF >>${CURRENT_DIR}/package.json
 {
   "name": "hello-world",
   "description": "hello world test on tsuru",
@@ -327,7 +350,7 @@ EOF
   }
 }
 EOF
-    cat <<EOF>>${CURRENT_DIR}/yarn.lock
+    cat <<EOF >>${CURRENT_DIR}/yarn.lock
 https://registry.yarnpkg.com/express
 EOF
     export NPM_REGISTRY=my-registry.example.com


### PR DESCRIPTION
Also the default yarn version and yarn version detection were improved
because some old yarn versions would always update files in node_modules
regardless if there were changes to package.json and lock file.
Caches from nvm, npm and yarn are now also cleared.