### PR TITLE
php: Fix ownership for generated Procfile

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -3,8 +3,9 @@
 # license that can be found in the LICENSE file.
 
 FROM  tsuru/base-platform:18.04
-ADD	. /var/lib/tsuru/php
-RUN	sudo cp /var/lib/tsuru/php/deploy /var/lib/tsuru
+COPY ./install /var/lib/tsuru/php/
 RUN set -ex; \
     sudo /var/lib/tsuru/php/install; \
     sudo rm -rf /var/lib/apt/lists/*
+ADD . /var/lib/tsuru/php
+RUN sudo cp /var/lib/tsuru/php/deploy /var/lib/tsuru

--- a/php/deploy.py
+++ b/php/deploy.py
@@ -67,29 +67,30 @@ class Manager(object):
         if self.interpretor is not None:
             self.interpretor.post_install()
 
+        self.update_alternatives(self.get_php_version())
+
+        if self.configuration.get('composer', True):
+            self.install_composer()
+
+    def create_procfile(self):
         # If there's no Procfile, create it
-        Procfile_path = os.path.join(self.application.get('directory'), 'Procfile')
+        procfile_path = os.path.join(self.application.get('directory'), 'Procfile')
         procfile_contents = None
-        if os.path.isfile(Procfile_path):
-            with open(Procfile_path, 'r') as f:
+        if os.path.isfile(procfile_path):
+            with open(procfile_path, 'r') as f:
                 web_match = re.search(r"^web:", f.read(), flags=re.MULTILINE)
                 if web_match is None:
                     f.seek(0)
                     procfile_contents = f.read()
 
-        if not os.path.isfile(Procfile_path) or procfile_contents:
-            with open(Procfile_path, 'w') as f:
+        if not os.path.isfile(procfile_path) or procfile_contents:
+            with open(procfile_path, 'w') as f:
                 f.write('web: /bin/bash -lc "sudo -E %s' % self.frontend.get_startup_cmd())
                 if self.interpretor is not None:
                     f.write(' && %s' % self.interpretor.get_startup_cmd(self.get_php_version()))
                 f.write(' "\n')
                 if procfile_contents:
                     f.write(procfile_contents)
-
-        self.update_alternatives(self.get_php_version())
-
-        if self.configuration.get('composer', True):
-            self.install_composer()
 
     def get_php_version(self):
         version = str(self.configuration.get('version', default_version))
@@ -121,6 +122,7 @@ class Manager(object):
         self.frontend.configure(self.interpretor)
 
     def setup_environment(self):
+        self.create_procfile()
         if self.interpretor is not None:
             self.interpretor.setup_environment()
 

--- a/tests/Dockerfile.template
+++ b/tests/Dockerfile.template
@@ -9,4 +9,4 @@ ADD common/* /tests/common/
 ADD https://github.com/sstephenson/bats/archive/master.tar.gz .
 RUN sudo mkdir ./bin && sudo tar -zxf master.tar.gz && sudo ./bats-master/install.sh .
 RUN echo "echo 'ran base deploy'" | sudo tee /var/lib/tsuru/base/deploy
-RUN sudo bin/bats common && sudo bin/bats .
+RUN bin/bats common && bin/bats .

--- a/tests/nodejs/tests.bats
+++ b/tests/nodejs/tests.bats
@@ -9,7 +9,6 @@ setup() {
     chown ubuntu /home/application/current
     export CURRENT_DIR=/home/application/current
     export PATH=/home/ubuntu/.nvm_bin:$PATH
-    su ubuntu
     rm -rf /home/ubuntu/.nvm_bin
     rm -rf /home/ubuntu/.nvm
 }

--- a/tests/php/tests.bats
+++ b/tests/php/tests.bats
@@ -16,6 +16,17 @@ setup() {
     [ "$output" == 'web: /bin/bash -lc "sudo -E /usr/sbin/apache2 -d /etc/apache2 -k start -DNO_DETACH "' ]
 }
 
+@test "sets correct ownership for generated Procfile allowing rewrites" {
+    run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+    run cat /home/application/current/Procfile
+    [ "$status" -eq 0 ]
+    [ "$output" == 'web: /bin/bash -lc "sudo -E /usr/sbin/apache2 -d /etc/apache2 -k start -DNO_DETACH "' ]
+    run stat -c '%U' /home/application/current/Procfile
+    [ "$status" -eq 0 ]
+    [[ "$output" == "ubuntu" ]]
+}
+
 @test "using php7.1 + apache-mod-php" {
     cat >/home/application/current/tsuru.yaml <<EOF
 php:
@@ -104,7 +115,7 @@ EOF
 EOF
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
-    run su - ubuntu -c "cd /home/application/current && composer_phar show"
+    run sh -c "cd /home/application/current && composer_phar show"
     match="ehime/hello-world .+"
     [[ $output =~ $match ]]
 }


### PR DESCRIPTION
Previously the generated `Procfile` would belong to the `root` user. This caused problems if the user tried to upload a custom `Procfile` as overwriting it would fail.