### PR TITLE
Adding git dependency to support 'go get' command in Go platform.

### DIFF
--- a/go/install
+++ b/go/install
@@ -8,7 +8,7 @@ SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/rc/config
 
 apt-get update
-apt-get install -y --no-install-recommends curl jq
+apt-get install -y --no-install-recommends curl jq git
 
 cp ${SOURCE_DIR}/go/Procfile ${SOURCE_DIR}/default/Procfile
 echo "export GOPATH=${APP_DIR}" | tee -a ${HOME}/.profile /etc/profile >/dev/null


### PR DESCRIPTION
I'm trying to deploy an application using `dep` as dependency management tool.
To setup I need to set a hook in tsuru.yaml file, example:

```
hooks:
  build:
    - go get github.com/golang/dep/cmd/dep
    - dep ensure -v -vendor-only
    - go build -o $HOME/app cmd/app/main.go

```

But during the deploy a received an error:

```
remote:  ---> Running "go get github.com/golang/dep/cmd/dep"
remote: go: missing Git command. See https://golang.org/s/gogetcmd
remote: package github.com/golang/dep/cmd/dep: exec: "git": executable file not found in $PATH
```

This pull request have objective add git dependency in golang tsuru base platform, suppporting correctly go get commands.
