### PR TITLE
python: use the new bucket, update versions and add 3.9

### DIFF
--- a/python/deploy
+++ b/python/deploy
@@ -8,7 +8,7 @@ SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/deploy
 source ${SOURCE_DIR}/base/rc/config
 
-PYTHON_REPO=${PYTHON_REPO:-https://lang-python.s3.amazonaws.com/heroku-18/runtimes}
+PYTHON_REPO=${PYTHON_REPO:-https://heroku-buildpack-python.s3.amazonaws.com/heroku-18/runtimes}
 GET_PIP_URL=${GET_PIP_URL:-https://bootstrap.pypa.io/get-pip.py}
 
 LATEST_38="3.8.1"

--- a/python/deploy
+++ b/python/deploy
@@ -11,14 +11,14 @@ source ${SOURCE_DIR}/base/rc/config
 PYTHON_REPO=${PYTHON_REPO:-https://heroku-buildpack-python.s3.amazonaws.com/heroku-18/runtimes}
 GET_PIP_URL=${GET_PIP_URL:-https://bootstrap.pypa.io/get-pip.py}
 
-LATEST_38="3.8.1"
-LATEST_37="3.7.6"
-LATEST_36="3.6.10"
-LATEST_35="3.5.7"
+LATEST_38="3.8.6"
+LATEST_37="3.7.9"
+LATEST_36="3.6.12"
+LATEST_35="3.5.10"
 LATEST_34="3.4.10"
-LATEST_27="2.7.17"
-PYPY_36="pypy3.6-7.2.0"
-PYPY_27="pypy2.7-7.2.0"
+LATEST_27="2.7.18"
+PYPY_36="pypy3.6-7.3.2"
+PYPY_27="pypy2.7-7.3.2"
 LATEST_PYTHON_VERSIONS=(${LATEST_38} ${LATEST_37} ${LATEST_36} ${LATEST_35} ${LATEST_34} ${LATEST_27} ${PYPY_36} ${PYPY_27})
 PYTHON_VERSION_DEFAULT="${LATEST_27}"
 VERSION_ORIGIN="default"

--- a/python/deploy
+++ b/python/deploy
@@ -11,6 +11,7 @@ source ${SOURCE_DIR}/base/rc/config
 PYTHON_REPO=${PYTHON_REPO:-https://heroku-buildpack-python.s3.amazonaws.com/heroku-18/runtimes}
 GET_PIP_URL=${GET_PIP_URL:-https://bootstrap.pypa.io/get-pip.py}
 
+LATEST_39="3.9.0"
 LATEST_38="3.8.6"
 LATEST_37="3.7.9"
 LATEST_36="3.6.12"
@@ -19,7 +20,7 @@ LATEST_34="3.4.10"
 LATEST_27="2.7.18"
 PYPY_36="pypy3.6-7.3.2"
 PYPY_27="pypy2.7-7.3.2"
-LATEST_PYTHON_VERSIONS=(${LATEST_38} ${LATEST_37} ${LATEST_36} ${LATEST_35} ${LATEST_34} ${LATEST_27} ${PYPY_36} ${PYPY_27})
+LATEST_PYTHON_VERSIONS=(${LATEST_39} ${LATEST_38} ${LATEST_37} ${LATEST_36} ${LATEST_35} ${LATEST_34} ${LATEST_27} ${PYPY_36} ${PYPY_27})
 PYTHON_VERSION_DEFAULT="${LATEST_27}"
 VERSION_ORIGIN="default"
 PYTHON_BASE_DIR="/home/application/python"

--- a/tests/python/tests.bats
+++ b/tests/python/tests.bats
@@ -14,40 +14,40 @@ setup() {
 
 @test "use python version 2.7 as default" {
     run /var/lib/tsuru/deploy
-    [[ "$output" == *"Using python version: 2.7.17"* ]]
+    [[ "$output" == *"Using python version: 2.7.18"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
     popd
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"2.7.17"* ]]
+    [[ "$output" == *"2.7.18"* ]]
 }
 
 @test "parse python version from .python-version" {
-    echo "3.5.7" > ${CURRENT_DIR}/.python-version
+    echo "3.5.10" > ${CURRENT_DIR}/.python-version
     run /var/lib/tsuru/deploy
-    [[ "$output" == *"Using python version: 3.5.7"* ]]
+    [[ "$output" == *"Using python version: 3.5.10"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
     popd
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.5.7"* ]]
+    [[ "$output" == *"3.5.10"* ]]
 }
 
 @test "parse python version from PYTHON_VERSION" {
-    export PYTHON_VERSION=3.5.7
+    export PYTHON_VERSION=3.5.10
     run /var/lib/tsuru/deploy
-    [[ "$output" == *"Using python version: 3.5.7"* ]]
+    [[ "$output" == *"Using python version: 3.5.10"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
     popd
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.5.7"* ]]
+    [[ "$output" == *"3.5.10"* ]]
     unset PYTHON_VERSION
 }
 
@@ -55,28 +55,28 @@ setup() {
     echo "xyz" > ${CURRENT_DIR}/.python-version
     run /var/lib/tsuru/deploy
     [[ "$output" == *"Python version 'xyz' (.python-version file) is not supported"* ]]
-    [[ "$output" == *"Using python version: 2.7.17"* ]]
+    [[ "$output" == *"Using python version: 2.7.18"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
     popd
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"2.7.17"* ]]
+    [[ "$output" == *"2.7.18"* ]]
 }
 
 @test "use python version 2.7 as default with invalid PYTHON_VERSION" {
     export PYTHON_VERSION=abc
     run /var/lib/tsuru/deploy
     [[ "$output" == *"Python version 'abc' (PYTHON_VERSION environment variable) is not supported"* ]]
-    [[ "$output" == *"Using python version: 2.7.17"* ]]
+    [[ "$output" == *"Using python version: 2.7.18"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
     popd
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"2.7.17"* ]]
+    [[ "$output" == *"2.7.18"* ]]
     unset PYTHON_VERSION
 }
 
@@ -128,115 +128,115 @@ EOF
     run python --version
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"2.7.17"* ]]
+    [[ "$output" == *"2.7.18"* ]]
 
-    export PYTHON_VERSION=3.5.7
+    export PYTHON_VERSION=3.5.10
     run /var/lib/tsuru/deploy
     run python --version
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.5.7"* ]]
+    [[ "$output" == *"3.5.10"* ]]
     unset PYTHON_VERSION
 }
 
 @test "reuses already installed python version" {
-    echo "3.5.7" > ${CURRENT_DIR}/.python-version
+    echo "3.5.10" > ${CURRENT_DIR}/.python-version
     run /var/lib/tsuru/deploy
-    [[ "$output" == *"Using python version: 3.5.7"* ]]
+    [[ "$output" == *"Using python version: 3.5.10"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
     popd
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.5.7"* ]]
+    [[ "$output" == *"3.5.10"* ]]
 
     run /var/lib/tsuru/deploy
-    [[ "$output" == *"Using already installed python version: 3.5.7"* ]]
+    [[ "$output" == *"Using already installed python version: 3.5.10"* ]]
 
     pushd ${CURRENT_DIR}
     run python --version
     popd
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.5.7"* ]]
+    [[ "$output" == *"3.5.10"* ]]
 }
 
 @test "change python version to closest version" {
     export PYTHON_VERSION=3.6.x
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Using python version: 3.6.10 (PYTHON_VERSION environment variable (closest))"* ]]
+    [[ "$output" == *"Using python version: 3.6.12 (PYTHON_VERSION environment variable (closest))"* ]]
     run python --version
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.6.10"* ]]
+    [[ "$output" == *"3.6.12"* ]]
 
     export PYTHON_VERSION=3.7.x
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Using python version: 3.7.6 (PYTHON_VERSION environment variable (closest))"* ]]
+    [[ "$output" == *"Using python version: 3.7.9 (PYTHON_VERSION environment variable (closest))"* ]]
     run python --version
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.7.6"* ]]
+    [[ "$output" == *"3.7.9"* ]]
 
     export PYTHON_VERSION=3.7
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Using already installed python version: 3.7.6"* ]]
+    [[ "$output" == *"Using already installed python version: 3.7.9"* ]]
     run python --version
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.7.6"* ]]
+    [[ "$output" == *"3.7.9"* ]]
 
     export PYTHON_VERSION=3
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Using python version: 3.8.1 (PYTHON_VERSION environment variable (closest))"* ]]
+    [[ "$output" == *"Using python version: 3.8.6 (PYTHON_VERSION environment variable (closest))"* ]]
     run python --version
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.8.1"* ]]
+    [[ "$output" == *"3.8.6"* ]]
 
     export PYTHON_VERSION=3.5.x
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Using python version: 3.5.7 (PYTHON_VERSION environment variable (closest))"* ]]
+    [[ "$output" == *"Using python version: 3.5.10 (PYTHON_VERSION environment variable (closest))"* ]]
     run python --version
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"3.5.7"* ]]
+    [[ "$output" == *"3.5.10"* ]]
 
     export PYTHON_VERSION=pypy2.7
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Using python version: pypy2.7-7.2.0 (PYTHON_VERSION environment variable (closest))"* ]]
+    [[ "$output" == *"Using python version: pypy2.7-7.3.2 (PYTHON_VERSION environment variable (closest))"* ]]
     run python --version
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"2.7"* ]]
-    [[ "$output" == *"7.2.0"* ]]
+    [[ "$output" == *"7.3.2"* ]]
 
     export PYTHON_VERSION=pypy3.6
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Using python version: pypy3.6-7.2.0 (PYTHON_VERSION environment variable (closest))"* ]]
+    [[ "$output" == *"Using python version: pypy3.6-7.3.2 (PYTHON_VERSION environment variable (closest))"* ]]
     run python --version
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"3.6"* ]]
-    [[ "$output" == *"7.2.0"* ]]
+    [[ "$output" == *"7.3.2"* ]]
 
     export PYTHON_VERSION=pypy3
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Using already installed python version: pypy3.6-7.2.0"* ]]
+    [[ "$output" == *"Using already installed python version: pypy3.6-7.3.2"* ]]
     run python --version
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"3.6"* ]]
-    [[ "$output" == *"7.2.0"* ]]
+    [[ "$output" == *"7.3.2"* ]]
 
     unset PYTHON_VERSION
 }

--- a/tests/python/tests.bats
+++ b/tests/python/tests.bats
@@ -190,7 +190,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"3.7.9"* ]]
 
-    export PYTHON_VERSION=3
+    export PYTHON_VERSION=3.8.x
     run /var/lib/tsuru/deploy
     [ "$status" -eq 0 ]
     [[ "$output" == *"Using python version: 3.8.6 (PYTHON_VERSION environment variable (closest))"* ]]
@@ -198,6 +198,24 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"3.8.6"* ]]
+
+    export PYTHON_VERSION=3.8
+    run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using already installed python version: 3.8.6"* ]]
+    run python --version
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"3.8.6"* ]]
+
+    export PYTHON_VERSION=3
+    run /var/lib/tsuru/deploy
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using python version: 3.9.0 (PYTHON_VERSION environment variable (closest))"* ]]
+    run python --version
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"3.9.0"* ]]
 
     export PYTHON_VERSION=3.5.x
     run /var/lib/tsuru/deploy


### PR DESCRIPTION
Heroku's Python Buildpack migrated to a new S3 bucket. Although the old one is not going to be deleted, it's **not** going to be updated anymore. Also, it doesn't include the latest version, 3.9.

Please check the indivudual commits for additional info.

🎃🍻🥨